### PR TITLE
Fix: don't allow to open a wallet if is already in tab

### DIFF
--- a/frontend/src/routes/Wallets.tsx
+++ b/frontend/src/routes/Wallets.tsx
@@ -1,4 +1,5 @@
 import { FlexboxGrid, IconButton, Stack } from "rsuite"
+
 import Nav from '@rsuite/responsive-nav';
 import { useEffect, useState } from "react";
 import { useAtom } from "jotai";
@@ -13,6 +14,7 @@ type Wallet = {
     label: string
 }
 
+const DERO_UNIT = 100000
 
 function Wallets() {
     var [data] = useAtom(appDataAtom)
@@ -22,7 +24,7 @@ function Wallets() {
         openWallets = openWallets.filter(wallet => Object.keys(data.wallets).includes(wallet.eventKey))
         setOpenWallets(openWallets);
         if (openWallets.findIndex((w) => w.eventKey == activeKey) >= 0 ) {
-            setActiveKey('status');
+            //setActiveKey('status');
         }
         
     }, [data])
@@ -76,9 +78,33 @@ function Wallets() {
                     </FlexboxGrid.Item>)}
                 </FlexboxGrid>
             })
-                .otherwise(_ => {
-                    return <div>Wallet actions are coming soon...</div>
-                })}
+            .otherwise(_ => {
+                if ( !data.wallets[activeKey].hasOwnProperty("address") ) {
+                    return (<div>Getting info...</div>)
+                } else {
+                    const address = data.wallets[activeKey]?.address ?? "Address not found"
+                    const balance = data.wallets[activeKey]?.balance ?? 0;
+                    const unlocked_balance = data.wallets[activeKey]?.unlocked_balance ?? 0;
+                    const balanceStr = `${balance/DERO_UNIT}/${unlocked_balance/DERO_UNIT}`;
+                    const transfers_entries = data.wallets[activeKey]?.transfers?.result.entries ?? {}
+                    //const transfers = data.wallets[activeKey]?.transfers?.result.entries.map( (transfer: any) => <div>{<pre>{JSON.stringify(transfer, null, 2)}</pre>}</div> )
+                    const transfers = transfers_entries.map( (transfer: any) => <div>{<pre>{JSON.stringify(transfer, null, 2)}</pre>}</div> )
+                    return (
+                        <>
+                        <div style={{ textAlign: "left" }}>
+                            <div>Address: {address}</div>
+                            <div>Balance: {balanceStr} DERO</div>
+                            <div>Transactions</div>
+                            <div style={{ background: "rgb(26, 29, 36)", padding: "2em", margin: '1em', borderRadius: "4px", maxHeight: "500px", overflowY: "scroll"}}>
+                                { transfers }
+                                
+                            
+                            </div>
+                        </div>
+                        </>
+                    )
+                }
+            })}
         </Stack.Item>
     </Stack>
 

--- a/frontend/src/routes/Wallets.tsx
+++ b/frontend/src/routes/Wallets.tsx
@@ -64,11 +64,14 @@ function Wallets() {
                     
                     {Object.keys(data.wallets).map((wallet, key) => <FlexboxGrid.Item key={key}>
                         <IconButton icon={<CreditCardPlusIcon />} style={styles.walletButton} onClick={() => {
-                            openWallets.push({
-                                eventKey: wallet,
-                                label: wallet[0].toUpperCase() + wallet.slice(1).replace('_', ' ')
-                            })
-                            setOpenWallets(openWallets)
+                            // If wallet_X is not open add it to openWallets
+                            if ( ! openWallets.some(item => item.eventKey === wallet) ) {
+                                openWallets.push({
+                                    eventKey: wallet,
+                                    label: wallet[0].toUpperCase() + wallet.slice(1).replace('_', ' ')
+                                })
+                                setOpenWallets(openWallets)
+                            }
                         }}>{wallet}</IconButton>
                     </FlexboxGrid.Item>)}
                 </FlexboxGrid>


### PR DESCRIPTION
I noticed that if you click on a wallet to add it to the tab list it add more tab for the same wallet.
Here's a quick fix.
Bye 
[image](https://user-images.githubusercontent.com/34693171/226682134-1f368dc5-0a57-46b0-a624-b51283b73317.png)